### PR TITLE
Stop  filtering records due to missing/invalid timestamp

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -19,5 +19,23 @@
         <property name="enable_load_extension" value="true" />
       </driver-properties>
     </data-source>
+    <data-source source="LOCAL" name="places [2]" uuid="3fd4dc9c-00e3-45e0-885f-f94102785dba">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/tests/firefox_databases/t87e6f86.test_profile1/places.sqlite</jdbc-url>
+      <driver-properties>
+        <property name="enable_load_extension" value="true" />
+      </driver-properties>
+    </data-source>
+    <data-source source="LOCAL" name="test_mozilla" uuid="f3c55ba7-70db-4b4f-8bd8-26054f1a4b81">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/tests/test_mozilla.sqlite</jdbc-url>
+      <driver-properties>
+        <property name="enable_load_extension" value="true" />
+      </driver-properties>
+    </data-source>
   </component>
 </project>

--- a/conftest.py
+++ b/conftest.py
@@ -13,12 +13,8 @@ def tests_root():
     return get_root_path('tests')
 
 @pytest.fixture(scope='session', autouse=True)
-def create_mozilla_data(tests_root):
-    db_path = str(Path(tests_root, 'test_mozilla.sqlite'))
-    try:
-        os.remove(db_path)
-    except FileNotFoundError:
-        pass
+def create_mozilla_data(tmpdir):
+    db_path = str(Path(tmpdir, 'test_mozilla.sqlite'))
     with sqlite3.connect(db_path) as conn:
         cur = conn.cursor()
         try:
@@ -49,12 +45,8 @@ def create_mozilla_data(tests_root):
 
 
 @pytest.fixture(scope='session', autouse=True)
-def create_chromium_data(tests_root):
-    db_path = str(Path(tests_root, 'test_chromium'))
-    try:
-        os.remove(db_path)
-    except FileNotFoundError:
-        pass
+def create_chromium_data(tmpdir):
+    db_path = str(Path(tmpdir, 'test_chromium'))
     with sqlite3.connect(db_path) as conn:
         cur = conn.cursor()
         cur.execute(

--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,7 @@ from flask.helpers import get_root_path
 def tests_root():
     return get_root_path('tests')
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(autouse=True)
 def create_mozilla_data(tmpdir):
     db_path = str(Path(tmpdir, 'test_mozilla.sqlite'))
     with sqlite3.connect(db_path) as conn:
@@ -44,7 +44,7 @@ def create_mozilla_data(tmpdir):
     return db_path
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(autouse=True)
 def create_chromium_data(tmpdir):
     db_path = str(Path(tmpdir, 'test_chromium'))
     with sqlite3.connect(db_path) as conn:
@@ -58,14 +58,14 @@ def create_chromium_data(tmpdir):
     return db_path
 
 
-@pytest.fixture(scope='session', autouse=True)
-def create_fake_non_db_file(tests_root):
-    fake_nondb_path = Path(tests_root, 'fake_nondb')
+@pytest.fixture(autouse=True)
+def create_fake_non_db_file(tmpdir):
+    fake_nondb_path = Path(tmpdir, 'fake_nondb')
     fake_nondb_path.write_bytes(b'0')
     return str(fake_nondb_path)
 
 
-@pytest.fixture(scope='session', autouse=True)
-def create_invalid_filepath(tests_root):
-    invalid_filepath = Path(tests_root, 'invalid_filepath')
+@pytest.fixture(autouse=True)
+def create_invalid_filepath(tmpdir):
+    invalid_filepath = Path(tmpdir, 'invalid_filepath')
     return str(invalid_filepath)

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 
 from pathlib import Path
@@ -14,50 +15,54 @@ def tests_root():
 @pytest.fixture(scope='session', autouse=True)
 def create_mozilla_data(tests_root):
     db_path = str(Path(tests_root, 'test_mozilla.sqlite'))
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
     try:
-        cur.execute(
-            '''CREATE TABLE moz_places ( id INTEGER PRIMARY KEY, url LONGVARCHAR, title LONGVARCHAR, rev_host LONGVARCHAR, visit_count INTEGER DEFAULT 0, hidden INTEGER DEFAULT 0 NOT NULL, typed INTEGER DEFAULT 0 NOT NULL, frecency INTEGER DEFAULT -1 NOT NULL, last_visit_date INTEGER , guid TEXT, foreign_count INTEGER DEFAULT 0 NOT NULL, url_hash INTEGER DEFAULT 0 NOT NULL , description TEXT, preview_image_url TEXT, origin_id INTEGER REFERENCES moz_origins(id))'''
-                )
-    except sqlite3.OperationalError:
+        os.remove(db_path)
+    except FileNotFoundError:
         pass
-    try:
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                '''CREATE TABLE IF NOT EXISTS moz_places ( id INTEGER, url LONGVARCHAR, title LONGVARCHAR, rev_host LONGVARCHAR, visit_count INTEGER DEFAULT 0, hidden INTEGER DEFAULT 0 NOT NULL, typed INTEGER DEFAULT 0 NOT NULL, frecency INTEGER DEFAULT -1 NOT NULL, last_visit_date INTEGER , guid TEXT, foreign_count INTEGER DEFAULT 0 NOT NULL, url_hash INTEGER DEFAULT 0 NOT NULL , description TEXT, preview_image_url TEXT, origin_id INTEGER REFERENCES moz_origins(id))'''
+                    )
+        except sqlite3.OperationalError:
+            pass
         cur.execute(
                 '''INSERT INTO moz_places VALUES ("13",	"https://www.linuxmint.com/start/tessa/", "Start Page - Linux Mint", "moc.tnimxunil.www.", "7", "0", "0", "37", "1547771594938637", "FJ1OyVWgG0Zb", "0", "47360064011053", "", "", "8")'''
                 )
         cur.execute(
-                '''INSERT INTO moz_places VALUES("1", "https://support.mozilla.org/en-US/products/firefox", " ",  "gro.allizom.troppus.", "0", "0", "0", "20", " ", "OH2P1G22WscA", "1", "47357795150914", "", "", "1")''',
+                '''INSERT INTO moz_places VALUES("1", "https://support.mozilla.org/en-US/products/firefox", " ",  "gro.allizom.troppus.", "0", "0", "0", "20", " ", "OH2P1G22WscA", "1", "47357795150914", "", "", "1")'''
                 )
         cur.execute(
-                '''INSERT INTO moz_places VALUES("1", "https://support.mozilla.org/en-US/products/firefox", " ",  "gro.allizom.troppus.", "0", "0", "0", "20", " ", "OH2P1G22WscA", "1", "478687686807678876867357795150914", "", "", "1")''',
+                '''INSERT INTO moz_places VALUES("1", "https://support.mozilla.org/en-US/products/firefox", " ",  "gro.allizom.troppus.", "0", "0", "0", "20", " ", "OH2P1G22WscA", "1", "478687686807678876867357795150914", "", "", "1")'''
                 )
-    except sqlite3.IntegrityError:
-        pass
-    conn.commit()
-    conn.close()
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+                '''CREATE TABLE IF NOT EXISTS moz_origins ( id INTEGER, prefix TEXT NOT NULL, host TEXT NOT NULL, frecency INTEGER NOT NULL)'''
+                )
+        cur.execute(
+                '''INSERT INTO moz_origins VALUES("1", "https://", "support.mozilla.org", "280")'''
+                )
+
     return db_path
 
 
 @pytest.fixture(scope='session', autouse=True)
 def create_chromium_data(tests_root):
     db_path = str(Path(tests_root, 'test_chromium'))
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
     try:
-        cur.execute(
-            '''CREATE TABLE urls(id INTEGER PRIMARY KEY AUTOINCREMENT,url LONGVARCHAR,title LONGVARCHAR,visit_count INTEGER DEFAULT 0 NOT NULL,typed_count INTEGER DEFAULT 0 NOT NULL,last_visit_time INTEGER NOT NULL,hidden INTEGER DEFAULT 0 NOT NULL)'''
-                )
-    except sqlite3.OperationalError:
+        os.remove(db_path)
+    except FileNotFoundError:
         pass
-    try:
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            '''CREATE TABLE IF NOT EXISTS urls(id INTEGER, url LONGVARCHAR,title LONGVARCHAR,visit_count INTEGER DEFAULT 0 NOT NULL,typed_count INTEGER DEFAULT 0 NOT NULL,last_visit_time INTEGER NOT NULL,hidden INTEGER DEFAULT 0 NOT NULL)'''
+                )
         cur.execute(
                 '''INSERT INTO urls VALUES ("88", "https://www.google.com/search?q=chrome+linux+profile+data&oq=chrome+linux+profile+data&aqs=chrome..69i57j33l4.3443j0j7&sourceid=chrome&ie=UTF-8", "chrome linux profile data - Google Search", "1", "0", "13204503690648295", "0")'''
                 )
-    except sqlite3.IntegrityError:
-        pass
-    conn.commit()
-    conn.close()
     return db_path
 
 

--- a/tests/unit_tests/test_table/test_Table_methods.py
+++ b/tests/unit_tests/test_table/test_Table_methods.py
@@ -9,7 +9,7 @@ from united_states_of_browsers.db_merge.table import Table
 from united_states_of_browsers.db_merge.custom_exceptions import TableAccessError
 
 
-def test_suite_no_exceptions_chromium(create_chromium_data):
+def test_table_no_exceptions_chromium_db_copy(create_chromium_data):
     with tempfile.TemporaryDirectory() as tempdir:
         chromium_db_path = create_chromium_data
         table_obj = Table(table='urls',
@@ -20,12 +20,13 @@ def test_suite_no_exceptions_chromium(create_chromium_data):
                           copies_subpath=tempdir,
                           )
         table_obj.make_records_yielder()
-        for entry in table_obj.records_yielder:
-            entry
+        records = list(table_obj.records_yielder)
+        assert len(records) == 1
+        assert records[0]['id'] == 88
         del table_obj
 
 
-def test_suite_no_exceptions_mozilla(create_mozilla_data):
+def test_table_no_exceptions_mozilla(create_mozilla_data):
     mozilla_db_path = create_mozilla_data
     table_obj = Table(table='moz_places',
                       path=mozilla_db_path,
@@ -35,9 +36,25 @@ def test_suite_no_exceptions_mozilla(create_mozilla_data):
                       copies_subpath=None,
                       )
     table_obj.make_records_yielder()
-    for entry in table_obj.records_yielder:
-        entry
+    records = list(table_obj.records_yielder)
+    assert len(records) == 3
+    assert [record['id'] for record in records] == [13, 1, 1]
 
+
+def test_table_another_table(create_mozilla_data):
+    mozilla_db_path = Path(create_mozilla_data)
+    table_obj = Table(table='moz_origins',
+                      path=mozilla_db_path,
+                      browser='firefox',
+                      filename='places.sqlite',
+                      profile='test_profile1',
+                      copies_subpath=None,
+                      )
+    table_obj.make_records_yielder()
+    records = list(table_obj.records_yielder)
+    assert len(records) == 1
+    assert records[0]['id'] ==1
+        
 
 def test_check_if_empty_db_true(create_chromium_data):
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/united_states_of_browsers/db_merge/table.py
+++ b/united_states_of_browsers/db_merge/table.py
@@ -87,13 +87,10 @@ class Table(dict):
             timestamp_ = record_dict.get('last_visit_date', record_dict.get('last_visit_time', None))
             try:
                 human_readable = dt.fromtimestamp(timestamp_ / 10 ** 6)
-            except TypeError as excep:
-                continue
-                pass  # records without valid timestamps are removed
-            except OSError:
-                continue  # records without valid timestamps are removed
-            
-            record_dict.update({'last_visit_readable': str(human_readable).split('.')[0]})
+            except (TypeError, OSError) as excep:  # records without valid timestamps
+                pass
+            else:
+                record_dict.update({'last_visit_readable': str(human_readable).split('.')[0]})
             yield record_dict
     
     def make_records_yielder(self, raise_exceptions=True):


### PR DESCRIPTION
 - Not all tables have a timestamp compatible field.
 - Many links queued on Mobile firefox but not visited don't have a timestamp but their presence in the history is important.