### PR TITLE
Use 3.9 to build as 3.6 is EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.9.16
 
     working_directory: ~/united-states-of-browsers
 


### PR DESCRIPTION
Signed-off-by: Kristoffer Grundström <lovaren@gmail.com>